### PR TITLE
Transferring a call should not require Active MediaSession

### DIFF
--- a/Tests/Unit/pjsip4net.Tests/Calls/given_a_call.cs
+++ b/Tests/Unit/pjsip4net.Tests/Calls/given_a_call.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Moq;
+using NUnit.Core.Builders;
 using NUnit.Framework;
 using pjsip4net.Calls;
 using pjsip4net.Core.Data;
@@ -20,8 +21,6 @@ namespace pjsip4net.Tests.Calls
         public void Setup()
         {
             _provider = _fixture.Freeze<Mock<ICallApiProvider>>();
-            _provider.Setup(x => x.GetInfo(It.IsAny<int>()))
-                .Returns(new CallInfo() { MediaStatus = CallMediaState.Active });
             _fixture.Register<ICallManagerInternal>(() => _fixture.CreateAnonymous<DefaultCallManager>()); 
             _sut = _fixture.Build<Call>().OmitAutoProperties().CreateAnonymous();
         }
@@ -47,10 +46,27 @@ namespace pjsip4net.Tests.Calls
             //assert
             _provider.Verify(x => x.TransferCall(It.Is<int>(x1 => x1 == _sut.Id), It.Is<string>(x1 => x1 == "sip:sip@sip")), Times.Never());
         }
-        
-        [Test]
-        public void when_transfer_in_active_media_state__should_delegate_call_to_provider()
+
+        [Test, Sequential]
+        public void when_transfer_it_should_depend_on_media_state__should_delegate_call_to_provider([
+                Values(
+                    CallMediaState.None,
+                    CallMediaState.Active,
+                    CallMediaState.Disconnected,
+                    CallMediaState.Error,
+                    CallMediaState.LocalHold,
+                    CallMediaState.RemoteHold)] CallMediaState mediaState, [Values(
+                                                                                true,
+                                                                                true,
+                                                                                false,
+                                                                                false,
+                                                                                false,
+                                                                                false
+                                                                            )] bool shouldDelegate)
         {
+            _provider.Setup(x => x.GetInfo(It.IsAny<int>()))
+                .Returns(new CallInfo() {MediaStatus = mediaState});
+
             //arrange
             _sut.SetId(_fixture.CreateAnonymous<int>());
             _sut.HandleMediaStateChanged();
@@ -59,7 +75,15 @@ namespace pjsip4net.Tests.Calls
             _sut.Transfer("sip:sip@sip");
 
             //assert
-            _provider.Verify(x => x.TransferCall(It.Is<int>(x1 => x1 == _sut.Id), It.Is<string>(x1 => x1 == "sip:sip@sip")), Times.Once());
+
+            if (shouldDelegate)
+            {
+                _provider.Verify(x => x.TransferCall(It.Is<int>(x1 => x1 == _sut.Id), It.Is<string>(x1 => x1 == "sip:sip@sip")), Times.Once());
+            }
+            else
+            {
+                _provider.Verify(x => x.TransferCall(It.Is<int>(x1 => x1 == _sut.Id), It.Is<string>(x1 => x1 == "sip:sip@sip")), Times.Never());
+            }
         }
 
         public void when_hangup__should_release_account()

--- a/pjsip4net/Calls/Call.cs
+++ b/pjsip4net/Calls/Call.cs
@@ -277,7 +277,7 @@ namespace pjsip4net.Calls
             GuardDisposed();
             Helper.GuardNotNullStr(destinationUri);
             Helper.GuardIsTrue(new SipUriParser(destinationUri).IsValid);
-            if (_mediaSession.IsActive)
+            if (_mediaSession.IsActive || this._mediaSession.MediaState == CallMediaState.None)
                 _callManager.CallApiProvider.TransferCall(Id, destinationUri);
         }
 


### PR DESCRIPTION
As we discussed in #66 you asked me to remove this check it to ignore the media state I thought it prudent to alter the check, and also the unit test to test all mediaStates, but regretfully not all states work as expected. I had a quick browse but it goes reasonably deep, that I did feel I could spend enough time on it. But with this fork you might have a quick glance and see if you spot what needs to be added
