### PR TITLE
Fix V3008

### DIFF
--- a/pjsip4net/DefaultSipUserAgent.cs
+++ b/pjsip4net/DefaultSipUserAgent.cs
@@ -30,7 +30,6 @@ namespace pjsip4net
             _basicApi = basicApi;
             _loggingConfig = loggingConfig;
             _container = container;
-            _loggingConfig = loggingConfig;
 
             eventsProvider.Subscribe<LogRequested>(OnLog);
         }


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- The '_loggingConfig' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 33, 31. pjsip4net DefaultSipUserAgent.cs 33